### PR TITLE
Removed dependency on CUDA in training.

### DIFF
--- a/tape/training.py
+++ b/tape/training.py
@@ -132,7 +132,7 @@ class BackwardRunner(ForwardRunner):
         self.max_grad_norm = max_grad_norm
         self._global_step = 0
         self._local_rank = local_rank
-        self._overflow_buf = torch.cuda.IntTensor([0])  # type: ignore
+        self._overflow_buf = torch.IntTensor([0])  # type: ignore
         self.gradient_accumulation_steps = gradient_accumulation_steps
         self._delay_accumulation = fp16 and local_rank != -1
 


### PR DESCRIPTION
The training modules should have the ability to train without GPU, hence the `no_cuda` flag, but there is an explicitly set cuda tensor that removes this capability. 