### PR TITLE
Allow torch 1.5 and 1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch>=1.0,<1.5
+torch>=1.0,<1.7
 tqdm
 tensorboardX
 scipy


### PR DESCRIPTION
I'd like to use tape in a project that requires at least pytorch 1.5, which currently conflicts with the requirement of <1.5. I've therefore extended the version range. I hope there are no breaking changes in 1.5 or 1.6 that affect tape.