### PR TITLE
Remove invalid UniRep token

### DIFF
--- a/tape/tokenizers.py
+++ b/tape/tokenizers.py
@@ -91,8 +91,7 @@ UNIREP_VOCAB = OrderedDict([
     ("Z", 23),
     ("B", 23),
     ("J", 23),
-    ("<cls>", 24),
-    ("<sep>", 25)])
+    ("<cls>", 24)])
 
 
 class TAPETokenizer():
@@ -106,7 +105,7 @@ class TAPETokenizer():
             self.vocab = UNIREP_VOCAB
         self.tokens = list(self.vocab.keys())
         self._vocab_type = vocab
-        assert self.start_token in self.vocab and self.stop_token in self.vocab
+        assert self.start_token in self.vocab
 
     @property
     def vocab_size(self) -> int:


### PR DESCRIPTION
UniRep gives outputs with dimensionality 25, so there is a bug with the dictionary.

I don’t think UniRep has a <sep> or stop token, so these should probably be left out.